### PR TITLE
change readme because well do all color urls and change config var name

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,10 @@ to any process in the Procfile to run stunnel alongside that process.
 
 ### Multiple Redis Instances
 
-If your application needs to connect to multiple Heroku Redis instances securely, you can set the
-`REDIS_URLS` config var to a list of config vars associated with the application:
+If your application needs to connect to multiple Heroku Redis instances securely, this buildpack
+will automatically create an Stunnel for each color Heroku Redis config var (`HEROKU_REDIS_COLOR`)
+and the `REDIS_URL` config var. If you have Redis urls that aren't in one of these config vars you
+will need to explicitly tell the buildpack that you need an Stunnel by setting the `REDIS_STUNNEL_URLS`
+config var to a list of the appropriate config vars:
 
-    $ heroku config:add REDIS_URLS="REDIS_URL HEROKU_REDIS_ROSE_URL"
+    $ heroku config:add REDIS_STUNNEL_URLS="CACHE_URL SESSION_STORE_URL"

--- a/bin/start-stunnel
+++ b/bin/start-stunnel
@@ -68,7 +68,7 @@ config-gen() {
   at config-gen-end
 
   # Overwrite config vars with stunnel targets
-  URLS=${REDIS_URLS:-REDIS_URL `compgen -v HEROKU_REDIS | grep -v STUNNEL`}
+  URLS=${REDIS_STUNNEL_URLS:-REDIS_URL `compgen -v HEROKU_REDIS | grep -v STUNNEL`}
 
   for URL in $URLS; do
     at "config-gen-override $URL"

--- a/bin/stunnel-conf.sh
+++ b/bin/stunnel-conf.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-URLS=${REDIS_URLS:-REDIS_URL `compgen -v HEROKU_REDIS`}
+URLS=${REDIS_STUNNEL_URLS:-REDIS_URL `compgen -v HEROKU_REDIS`}
 n=1
 
 mkdir -p /app/vendor/stunnel/var/run/stunnel/


### PR DESCRIPTION
didn't like using the plural `REDIS_URLS`.  we had so many problems with pgbackups when we used plural of schedule.
