### PR TITLE
Add an option to force TLSv1

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,12 @@ Redis:
 The buildpack will install and configure stunnel to connect to `REDIS_URL` over a SSL connection. Prepend `bin/start-stunnel`
 to any process in the Procfile to run stunnel alongside that process.
 
+### Stunnel settings
+
+Some settings are configurable through app config vars at runtime:
+
+- ``STUNNEL_ENABLED``: Default to true, enable or disable stunnel.
+- ``STUNNEL_FORCE_TLS``: Default is unset. Set this var, to force TLSv1 on cedar-10.
 
 ### Multiple Redis Instances
 

--- a/bin/stunnel-conf.sh
+++ b/bin/stunnel-conf.sh
@@ -2,6 +2,13 @@
 URLS=${REDIS_STUNNEL_URLS:-REDIS_URL `compgen -v HEROKU_REDIS`}
 n=1
 
+# Enable this option to prevent stunnel from using SSLv3 with cedar-10
+if [ -z "${STUNNEL_FORCE_TLS}" ]; then
+  STUNNEL_FORCE_SSL_VERSION=""
+else
+  STUNNEL_FORCE_SSL_VERSION="sslVersion = TLSv1"
+fi
+
 mkdir -p /app/vendor/stunnel/var/run/stunnel/
 
 cat >> /app/vendor/stunnel/stunnel.conf << EOFEOF
@@ -14,6 +21,7 @@ options = SINGLE_ECDH_USE
 options = SINGLE_DH_USE
 socket = r:TCP_NODELAY=1
 options = NO_SSLv3
+${STUNNEL_FORCE_SSL_VERSION}
 ciphers = HIGH:!ADH:!AECDH:!LOW:!EXP:!MD5:!3DES:!SRP:!PSK:@STRENGTH
 EOFEOF
 


### PR DESCRIPTION
Stunnel bundled with cedar-10 will try to connect via SSLv3 which will fail, this allow to force stunnel to use TLSv1.
