### PR TITLE
Remove support for the Cedar-10 stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,6 @@ to any process in the Procfile to run stunnel alongside that process.
 Some settings are configurable through app config vars at runtime:
 
 - ``STUNNEL_ENABLED``: Default to true, enable or disable stunnel.
-- ``STUNNEL_FORCE_TLS``: Default is unset. Set this var, to force TLSv1 on cedar-10.
 
 ### Multiple Redis Instances
 

--- a/bin/stunnel-conf.sh
+++ b/bin/stunnel-conf.sh
@@ -2,13 +2,6 @@
 URLS=${REDIS_STUNNEL_URLS:-REDIS_URL `compgen -v HEROKU_REDIS`}
 n=1
 
-# Enable this option to prevent stunnel from using SSLv3 with cedar-10
-if [ -z "${STUNNEL_FORCE_TLS}" ]; then
-  STUNNEL_FORCE_SSL_VERSION=""
-else
-  STUNNEL_FORCE_SSL_VERSION="sslVersion = TLSv1"
-fi
-
 mkdir -p /app/vendor/stunnel/var/run/stunnel/
 
 cat >> /app/vendor/stunnel/stunnel.conf << EOFEOF
@@ -22,7 +15,6 @@ options = SINGLE_DH_USE
 socket = r:TCP_NODELAY=1
 options = NO_SSLv3
 TIMEOUTidle = 86400
-${STUNNEL_FORCE_SSL_VERSION}
 ciphers = HIGH:!ADH:!AECDH:!LOW:!EXP:!MD5:!3DES:!SRP:!PSK:@STRENGTH
 EOFEOF
 


### PR DESCRIPTION
Since it's no longer possible to build a cedar-10 app anyway:
https://devcenter.heroku.com/changelog-items/755