### PR TITLE
Overwrite any existing stunnel.conf rather than appending

### DIFF
--- a/bin/stunnel-conf.sh
+++ b/bin/stunnel-conf.sh
@@ -4,7 +4,7 @@ n=1
 
 mkdir -p /app/vendor/stunnel/var/run/stunnel/
 
-cat >> /app/vendor/stunnel/stunnel.conf << EOFEOF
+cat > /app/vendor/stunnel/stunnel.conf << EOFEOF
 foreground = yes
 
 pid = /app/vendor/stunnel/stunnel4.pid


### PR DESCRIPTION
Otherwise running `start-stunnel <COMMAND>` multiple times (such as in a one-off dyno when running a command and then killing it) will result in an stunnel.conf that has invalid syntax due to the global options being appended after the per-server header.

Based on:
https://github.com/heroku/heroku-buildpack-pgbouncer/pull/83