### PR TITLE
Add support for heroku-18

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -15,7 +15,11 @@ BUILDPACK_DIR="$(dirname $(dirname $0))"
 
 echo "-----> Moving the configuration generation script into app/bin"
 mkdir -p $BUILD_DIR/bin
-cp "$BUILDPACK_DIR/bin/stunnel-conf.sh" $BUILD_DIR/bin
+if [ "$STACK" == "heroku-18" ]; then
+  cp "$BUILDPACK_DIR/bin/stunnel-conf.sh" $BUILD_DIR/bin/stunnel-conf.sh
+else
+  cp "$BUILDPACK_DIR/bin/legacy-stunnel-conf.sh" $BUILD_DIR/bin/stunnel-conf.sh
+fi
 chmod +x $BUILD_DIR/bin/stunnel-conf.sh
 
 echo "-----> Moving the start-stunnel script into app/bin"

--- a/bin/legacy-stunnel-conf.sh
+++ b/bin/legacy-stunnel-conf.sh
@@ -9,6 +9,9 @@ foreground = yes
 
 pid = /app/vendor/stunnel/stunnel4.pid
 
+options = NO_SSLv2
+options = SINGLE_ECDH_USE
+options = SINGLE_DH_USE
 socket = r:TCP_NODELAY=1
 options = NO_SSLv3
 TIMEOUTidle = 86400


### PR DESCRIPTION
Add support for `heroku-18` by special casing configuration for old stacks, at least until `heroku-16` is deprecated.

This fixes #24.
