### PR TITLE
Test the buildpack in CI

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+.git/
+support/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+language: bash
+services:
+  - docker
+env:
+  - STACK=cedar-14
+  - STACK=heroku-16
+  - STACK=heroku-18
+script:
+  - ./support/test.sh "${STACK}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,26 @@
+ARG BUILD_IMAGE
+ARG RUNTIME_IMAGE
+FROM $BUILD_IMAGE AS builder
+
+ARG STACK
+
+# Emulate the platform where root access is not available
+RUN useradd -d /app non-root-user
+RUN mkdir -p /app /cache /env
+RUN chown non-root-user /app /cache /env
+USER non-root-user
+
+COPY --chown=non-root-user . /buildpack
+WORKDIR /app
+
+# Sanitize the environment seen by the buildpack, to prevent reliance on
+# environment variables that won't be present when run on the platform.
+RUN env -i PATH=$PATH HOME=$HOME STACK=$STACK /buildpack/bin/detect /app
+RUN env -i PATH=$PATH HOME=$HOME STACK=$STACK /buildpack/bin/compile /app /cache /env
+
+
+FROM $RUNTIME_IMAGE
+RUN useradd -d /app non-root-user
+USER non-root-user
+COPY --from=builder --chown=non-root-user /app /app
+WORKDIR /app

--- a/support/test.sh
+++ b/support/test.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+[ $# -eq 1 ] || { echo "Usage: $0 STACK"; exit 1; }
+
+STACK="${1}"
+
+RUNTIME_IMAGE="heroku/${STACK/-/:}"
+
+if [[ "${STACK}" == "cedar-14" ]]; then
+    BUILD_IMAGE="${RUNTIME_IMAGE}"
+else
+    BUILD_IMAGE="${RUNTIME_IMAGE}-build"
+fi
+
+OUTPUT_IMAGE="redis-stunnel-test-${STACK}"
+
+echo "Building buildpack on stack ${STACK}..."
+
+docker build \
+    --build-arg "BUILD_IMAGE=${BUILD_IMAGE}" \
+    --build-arg "RUNTIME_IMAGE=${RUNTIME_IMAGE}" \
+    --build-arg "STACK=${STACK}" \
+    -t "${OUTPUT_IMAGE}" \
+    .
+
+echo "Checking the start-stunnel wrapper works and stunnel can start..."
+
+# Ideally this would check the value of REDIS_URL, however bugs in start-tunnel make
+# testing this annoying (eg https://github.com/heroku/heroku-buildpack-redis/issues/13
+# and hangs if I try to capture the output), but this is better than nothing for now.
+TEST_COMMAND="bin/start-stunnel bash -c 'sleep 2 && env && cat /app/vendor/stunnel/stunnel.conf'"
+docker run --rm -it --env 'REDIS_URL=redis://h:secret@example.tld:1234' "${OUTPUT_IMAGE}" bash -c "set -ex && ${TEST_COMMAND}"
+
+echo "Success!"


### PR DESCRIPTION
Since previously the Travis run was a no-op, and we're about to add support for a new stack (in the next PR), which would be good to be able to test properly.

Uses an approach similar to that in:
https://github.com/heroku/heroku-buildpack-google-chrome
https://github.com/heroku/heroku-buildpack-ci-postgresql
https://github.com/heroku/heroku-buildpack-ci-redis

Whilst the test here doesn't yet check `REDIS_URL` or actually make use of the stunnel connection with Redis (would require setting up Redis server with stunnel), it at least ensures the buildpack compiles successfully, and also would have caught the error seen in #24.

Refs [W-7507192](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07B0000007oK9nIAE/view).