### PR TITLE
Excluded heroku-16 stack from legacy

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -15,7 +15,7 @@ BUILDPACK_DIR="$(dirname $(dirname $0))"
 
 echo "-----> Moving the configuration generation script into app/bin"
 mkdir -p $BUILD_DIR/bin
-if [[ "$STACK" == "cedar-14" || "$STACK" == "heroku-16" ]]; then
+if [[ "$STACK" == "cedar-14" ]]; then
   cp "$BUILDPACK_DIR/bin/legacy-stunnel-conf.sh" $BUILD_DIR/bin/stunnel-conf.sh
 else
   cp "$BUILDPACK_DIR/bin/stunnel-conf.sh" $BUILD_DIR/bin/stunnel-conf.sh


### PR DESCRIPTION
Heroku-16 will probably hit EOL on 30th April, 2021. This change is breaking for stacks on heroku-16 which are using stunnel.

We can chuck it off once it reaches EOL.