### PR TITLE
Document that this buildpack is only for Heroku Redis 5 and older

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@ This is a [Heroku buildpack](http://devcenter.heroku.com/articles/buildpacks) th
 allows an application to use an [stunnel](http://stunnel.org) to connect securely to
 Heroku Redis.  It is meant to be used in conjunction with other buildpacks.
 
+**This buildpack is only for use with Heroku Redis 4 and 5. For Heroku Redis 6 and newer, use its built-in TLS support instead.**
+
+**For more information, see [Securing Heroku Redis](https://devcenter.heroku.com/articles/securing-heroku-redis).**
+
 ## Usage
 
 First, ensure your Heroku Redis addon is using a production tier plan. SSL is not


### PR DESCRIPTION
Since with Heroku Redis 6 and newer, the built-in TLS support should be used instead:
https://devcenter.heroku.com/articles/securing-heroku-redis