### PR TITLE
Add Heroku-22 to the Circle CI test matrix

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,8 @@ version: 2.1
 
 jobs:
   test:
-    machine: true
+    machine:
+      image: ubuntu-2004:current
     parameters:
       stack:
         type: "string"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,3 +20,6 @@ workflows:
       - test:
           name: Heroku-20 Test
           stack: heroku-20
+      - test:
+          name: Heroku-22 Test
+          stack: heroku-22


### PR DESCRIPTION
In order for the Circle CI run to successfully run, I also had to bump the `machine` image, per:
https://circleci.com/docs/2.0/images/linux-vm/16.04-to-20.04-migration/

GUS-W-10346692.