### PR TITLE
don't override URL with stunnel url if `rediss`

### DIFF
--- a/bin/start-stunnel
+++ b/bin/start-stunnel
@@ -71,8 +71,13 @@ config-gen() {
   URLS=${REDIS_STUNNEL_URLS:-REDIS_URL `compgen -v HEROKU_REDIS | grep -v STUNNEL`}
 
   for URL in $URLS; do
-    at "config-gen-override $URL"
-    eval "$URL=\$${URL}_STUNNEL"
+    eval URL_VALUE=\$$URL
+    if [[ $URL_VALUE =~ rediss://* ]]; then
+      at "config-gen-skip $URL"
+    else
+      at "config-gen-override $URL"
+      eval "$URL=\$${URL}_STUNNEL"
+    fi
   done
 }
 

--- a/bin/stunnel-conf.sh
+++ b/bin/stunnel-conf.sh
@@ -20,11 +20,6 @@ for URL in $URLS
 do
   eval URL_VALUE=\$$URL
 
-  if [[ $URL_VALUE =~ rediss://* ]]; then
-    echo "Skipping $URL"
-    continue
-  fi
-
   PARTS=$(echo $URL_VALUE | perl -lne 'print "$1 $2 $3 $4 $5 $6 $7" if /^([^:]+):\/\/([^:]+):([^@]+)@(.*?):(.*?)(\/(.*?)(\\?.*))?$/')
   if [ -z "$PARTS" ]
   then

--- a/bin/stunnel-conf.sh
+++ b/bin/stunnel-conf.sh
@@ -19,7 +19,6 @@ EOFEOF
 for URL in $URLS
 do
   eval URL_VALUE=\$$URL
-
   PARTS=$(echo $URL_VALUE | perl -lne 'print "$1 $2 $3 $4 $5 $6 $7" if /^([^:]+):\/\/([^:]+):([^@]+)@(.*?):(.*?)(\/(.*?)(\\?.*))?$/')
   if [ -z "$PARTS" ]
   then

--- a/bin/stunnel-conf.sh
+++ b/bin/stunnel-conf.sh
@@ -32,6 +32,8 @@ do
     WITHOUT_USERNAME=true
   fi
   URI=( $PARTS )
+
+
   if [ "$WITHOUT_USERNAME" = true ] ; then
     URI_SCHEME=${URI[0]}
     URI_PASS=${URI[1]}

--- a/bin/stunnel-conf.sh
+++ b/bin/stunnel-conf.sh
@@ -19,6 +19,12 @@ EOFEOF
 for URL in $URLS
 do
   eval URL_VALUE=\$$URL
+
+  if [[ $URL_VALUE =~ rediss://* ]]; then
+    echo "Skipping $URL"
+    continue
+  fi
+
   PARTS=$(echo $URL_VALUE | perl -lne 'print "$1 $2 $3 $4 $5 $6 $7" if /^([^:]+):\/\/([^:]+):([^@]+)@(.*?):(.*?)(\/(.*?)(\\?.*))?$/')
   if [ -z "$PARTS" ]
   then
@@ -26,8 +32,6 @@ do
     WITHOUT_USERNAME=true
   fi
   URI=( $PARTS )
-
-
   if [ "$WITHOUT_USERNAME" = true ] ; then
     URI_SCHEME=${URI[0]}
     URI_PASS=${URI[1]}

--- a/support/test.sh
+++ b/support/test.sh
@@ -27,6 +27,6 @@ echo "Checking the start-stunnel wrapper works and stunnel can start..."
 TEST_COMMAND="bin/start-stunnel bash -c 'sleep 2 && env && cat /app/vendor/stunnel/stunnel.conf'"
 docker run --rm -t --env 'REDIS_URL=redis://:secret@example.tld:1234' "${OUTPUT_IMAGE}" bash -c "set -ex && ${TEST_COMMAND}"
 docker run --rm -t --env 'REDIS_URL=redis://h:secret@example.tld:1234' "${OUTPUT_IMAGE}" bash -c "set -ex && ${TEST_COMMAND}"
-docker run --rm -t --env 'REDIS_URL=rediss://h:secret@example.tld:1234' "${OUTPUT_IMAGE}" bash -c "set -ex && ${TEST_COMMAND}"
+docker run --rm -t --env 'REDIS_URL=rediss://:secret@example.tld:1234' "${OUTPUT_IMAGE}" bash -c "set -ex && ${TEST_COMMAND}"
 
 echo "Success!"

--- a/support/test.sh
+++ b/support/test.sh
@@ -27,5 +27,6 @@ echo "Checking the start-stunnel wrapper works and stunnel can start..."
 TEST_COMMAND="bin/start-stunnel bash -c 'sleep 2 && env && cat /app/vendor/stunnel/stunnel.conf'"
 docker run --rm -t --env 'REDIS_URL=redis://:secret@example.tld:1234' "${OUTPUT_IMAGE}" bash -c "set -ex && ${TEST_COMMAND}"
 docker run --rm -t --env 'REDIS_URL=redis://h:secret@example.tld:1234' "${OUTPUT_IMAGE}" bash -c "set -ex && ${TEST_COMMAND}"
+docker run --rm -t --env 'REDIS_URL=rediss://h:secret@example.tld:1234' "${OUTPUT_IMAGE}" bash -c "set -ex && ${TEST_COMMAND}"
 
 echo "Success!"


### PR DESCRIPTION
This PR skips adding _STUNNEL config if Redis Addon is using SSL. 

Testing:
1. Added buildpack to testing app (with a Redis 4 and a Redis 6)
2. tailed the logs
```
2023-02-14T16:54:19.604010+00:00 app[web.1]: buildpack=stunnel at=stunnel-enabled
2023-02-14T16:54:19.604072+00:00 app[web.1]: buildpack=stunnel at=config-gen-start
2023-02-14T16:54:19.614642+00:00 app[web.1]: Setting FOUR_URL_STUNNEL config var
2023-02-14T16:54:19.616368+00:00 app[web.1]: Skipping REDIS_URL
2023-02-14T16:54:19.618041+00:00 app[web.1]: buildpack=stunnel at=config-gen-end
2023-02-14T16:54:19.618113+00:00 app[web.1]: buildpack=stunnel at=config-gen-override FOUR_URL
2023-02-14T16:54:19.618176+00:00 app[web.1]: buildpack=stunnel at=config-gen-skip REDIS_URL
```
