### PR TITLE
maint: update for heroku-24

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -14,7 +14,8 @@ jobs:
           - heroku-18
           - heroku-20
           - heroku-22
+          - heroku-24
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - run: bash support/test.sh ${{ matrix.stack }}

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -14,7 +14,6 @@ jobs:
           - heroku-18
           - heroku-20
           - heroku-22
-          - heroku-24
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ FROM $BUILD_IMAGE AS builder
 ARG STACK
 
 # Emulate the platform where root access is not available
+USER root
 RUN useradd -d /app non-root-user
 RUN mkdir -p /app /cache /env
 RUN chown non-root-user /app /cache /env
@@ -20,6 +21,7 @@ RUN env -i PATH=$PATH HOME=$HOME STACK=$STACK /buildpack/bin/compile /app /cache
 
 
 FROM $RUNTIME_IMAGE
+USER root
 RUN useradd -d /app non-root-user
 USER non-root-user
 COPY --from=builder --chown=non-root-user /app /app

--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@ allows an application to use an [stunnel](http://stunnel.org) to connect securel
 Heroku Redis.  It is meant to be used in conjunction with other buildpacks.
 
 > [!WARNING]
-> This buildpack isn’t compatible with [`heroku-24`](article link?) and later. You don’t need this buildpack for Redis 6+, which supports native TLS.
-
+> This buildpack isn’t compatible with `heroku-24` and later. You don’t need this buildpack for Redis 6+, which supports native TLS.
+>
 > For more information, see [Securing Heroku Redis](https://devcenter.heroku.com/articles/heroku-redis#security-and-compliance).
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@ This is a [Heroku buildpack](http://devcenter.heroku.com/articles/buildpacks) th
 allows an application to use an [stunnel](http://stunnel.org) to connect securely to
 Heroku Redis.  It is meant to be used in conjunction with other buildpacks.
 
-**This buildpack is only for use with Heroku Redis 4 and 5. For Heroku Redis 6 and newer, use its built-in TLS support instead.**
-
-**For more information, see [Securing Heroku Redis](https://devcenter.heroku.com/articles/securing-heroku-redis).**
+> [!WARNING]
+> This buildpack is not compatible with `heroku-24`+ and is not needed for Redis 6+, which supports native TLS.
+> For more information, see [Securing Heroku Redis](https://devcenter.heroku.com/articles/heroku-redis#security-and-compliance).
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,8 @@ allows an application to use an [stunnel](http://stunnel.org) to connect securel
 Heroku Redis.  It is meant to be used in conjunction with other buildpacks.
 
 > [!WARNING]
-> This buildpack is not compatible with `heroku-24`+ and is not needed for Redis 6+, which supports native TLS.
+> This buildpack isn’t compatible with [`heroku-24`](article link?) and later. You don’t need this buildpack for Redis 6+, which supports native TLS.
+
 > For more information, see [Securing Heroku Redis](https://devcenter.heroku.com/articles/heroku-redis#security-and-compliance).
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ allows an application to use an [stunnel](http://stunnel.org) to connect securel
 Heroku Redis.  It is meant to be used in conjunction with other buildpacks.
 
 > [!WARNING]
-> This buildpack isn’t compatible with `heroku-24` and later. You don’t need this buildpack for Redis 6+, which supports native TLS.
+> This buildpack isn’t compatible with the `heroku-24` [stack](https://devcenter.heroku.com/articles/stack) and later. You don’t need this buildpack for Redis 6+, which supports native TLS.
 >
 > For more information, see [Securing Heroku Redis](https://devcenter.heroku.com/articles/heroku-redis#security-and-compliance).
 

--- a/bin/compile
+++ b/bin/compile
@@ -13,6 +13,14 @@ unset GIT_DIR
 BUILD_DIR=$1
 BUILDPACK_DIR="$(dirname $(dirname $0))"
 
+STUNNEL=$(command -v stunnel4)
+
+if [ -z $STUNNEL ]; then
+    echo "------> stunnel not detected! stunnel not supported on heroku-24+"
+    echo "------> this buildpack is not required for Redis 6+: https://devcenter.heroku.com/articles/heroku-redis#security-and-compliance"
+    exit 1
+fi
+
 echo "-----> Moving the configuration generation script into app/bin"
 mkdir -p $BUILD_DIR/bin
 cp "$BUILDPACK_DIR/bin/stunnel-conf.sh" $BUILD_DIR/bin/stunnel-conf.sh

--- a/bin/compile
+++ b/bin/compile
@@ -15,10 +15,11 @@ BUILDPACK_DIR="$(dirname $(dirname $0))"
 
 if ! command -v stunnel4 > /dev/null; then
 
-    echo "! This buildpack uses stunnel, which isn’t supported on heroku-24 and later."
-    echo "! You don’t need this buildpack for Redis 6+. Remove it with the command:"
-    echo "! $ heroku buildpacks:remove heroku/redis"
-    echo "! To use Redis’ native TLS support, see https://devcenter.heroku.com/articles/heroku-redis#security-and-compliance."
+    echo "! This buildpack uses stunnel, which isn’t supported on heroku-24 and later." >&2
+    echo "! You don’t need this buildpack for Redis 6+. Remove it with the command:" >&2
+    echo "! $ heroku buildpacks:remove heroku/redis" >&2
+    echo "! To use Redis’ native TLS support, see https://devcenter.heroku.com/articles/heroku-redis#security-and-compliance:" >&2
+    echo "! https://devcenter.heroku.com/articles/heroku-redis#security-and-compliance" >&2
 
     exit 1
 fi

--- a/bin/compile
+++ b/bin/compile
@@ -14,11 +14,12 @@ BUILD_DIR=$1
 BUILDPACK_DIR="$(dirname $(dirname $0))"
 
 if ! command -v stunnel4 > /dev/null; then
-    echo "!     stunnel not detected! stunnel not supported on heroku-24+"
-    echo "!     This buildpack is not required for Redis 6+. Remove this buildpack using:"
-    echo "!         $ heroku buildpacks:remove heroku/redis"
-    echo "!     And then follow the instructions for using Redis' native TLS support:"
-    echo "!     https://devcenter.heroku.com/articles/heroku-redis#security-and-compliance"
+
+    echo "! This buildpack uses stunnel, which isn’t supported on heroku-24 and later."
+    echo "! You don’t need this buildpack for Redis 6+. Remove it with the command:"
+    echo "! $ heroku buildpacks:remove heroku/redis"
+    echo "! To use Redis’ native TLS support, see https://devcenter.heroku.com/articles/heroku-redis#security-and-compliance."
+
     exit 1
 fi
 

--- a/bin/compile
+++ b/bin/compile
@@ -13,11 +13,12 @@ unset GIT_DIR
 BUILD_DIR=$1
 BUILDPACK_DIR="$(dirname $(dirname $0))"
 
-STUNNEL=$(command -v stunnel4)
-
-if [ -z $STUNNEL ]; then
-    echo "------> stunnel not detected! stunnel not supported on heroku-24+"
-    echo "------> this buildpack is not required for Redis 6+: https://devcenter.heroku.com/articles/heroku-redis#security-and-compliance"
+if ! command -v stunnel4 > /dev/null; then
+    echo "!     stunnel not detected! stunnel not supported on heroku-24+"
+    echo "!     This buildpack is not required for Redis 6+. Remove this buildpack using:"
+    echo "!         $ heroku buildpacks:remove heroku/redis"
+    echo "!     And then follow the instructions for using Redis' native TLS support:"
+    echo "!     https://devcenter.heroku.com/articles/heroku-redis#security-and-compliance"
     exit 1
 fi
 

--- a/bin/start-stunnel
+++ b/bin/start-stunnel
@@ -1,14 +1,6 @@
 #!/usr/bin/env bash
 
 main() {
-  STUNNEL=$(command -v stunnel4)
-
-  if [ -z $STUNNEL ]; then
-      echo "buildpack=stunnel at=error stunnel not detected! stunnel not supported on heroku-24+"
-      echo "buildpack=stunnel at=error this buildpack is not required for Redis 6+: https://devcenter.heroku.com/articles/heroku-redis#security-and-compliance"
-      exit 1
-  fi
-
   if ! is-enabled "${STUNNEL_ENABLED:-1}"; then
     at stunnel-disabled
     exec "$@"

--- a/bin/start-stunnel
+++ b/bin/start-stunnel
@@ -1,6 +1,14 @@
 #!/usr/bin/env bash
 
 main() {
+  STUNNEL=$(command -v stunnel4)
+
+  if [ -z $STUNNEL ]; then
+      echo "buildpack=stunnel at=error stunnel not detected! stunnel not supported on heroku-24+"
+      echo "buildpack=stunnel at=error this buildpack is not required for Redis 6+: https://devcenter.heroku.com/articles/heroku-redis#security-and-compliance"
+      exit 1
+  fi
+
   if ! is-enabled "${STUNNEL_ENABLED:-1}"; then
     at stunnel-disabled
     exec "$@"


### PR DESCRIPTION
Ref: GUS-W-14682575.

```🕙[ 06:39:33 ] ➜ git push heroku main
Enumerating objects: 5, done.
Counting objects: 100% (5/5), done.
Delta compression using up to 10 threads
Compressing objects: 100% (2/2), done.
Writing objects: 100% (3/3), 263 bytes | 263.00 KiB/s, done.
Total 3 (delta 1), reused 0 (delta 0), pack-reused 0
remote: Updated 82 paths from 1300fa5
remote: Compressing source files... done.
remote: Building source:
remote: Waiting on build...
remote: Waiting on build... (elapsed: 6s)
remote:
remote: -----> Building on the Heroku-24 stack
remote: -----> Using buildpacks:
remote:        1. https://github.com/heroku/heroku-buildpack-redis.git#mble-sfdc-support-heroku-24
remote:        2. https://github.com/heroku/heroku-buildpack-pgbouncer.git#add-support-for-heroku-24
remote: -----> Redis-stunnel app detected
remote: !     stunnel not detected! stunnel not supported on heroku-24+
remote: !     This buildpack is not required for Redis 6+. Remove this buildpack using:
remote: !         $ heroku buildpacks:remove heroku/redis
remote: !     And then follow the instructions for using Redis' native TLS support:
remote: !     https://devcenter.heroku.com/articles/heroku-redis#security-and-compliance
remote:  !     Push rejected, failed to compile Redis-stunnel app.
remote:
remote:  !     Push failed
remote:  !
remote:  ! ## Warning - The same version of this code has already been built: 3f47d00f92c718e444e865c6667e2014b2d6ab95
remote:  !
remote:  ! We have detected that you have triggered a build from source code with version 3f47d00f92c718e444e865c6667e2014b2d6ab95
remote:  ! at least twice. One common cause of this behavior is attempting to deploy code from a different branch.
remote:  !
remote:  ! If you are developing on a branch and deploying via git you must run:
remote:  !
remote:  !     git push heroku <branchname>:main
remote:  !
remote:  ! This article goes into details on the behavior:
remote:  !   https://devcenter.heroku.com/articles/duplicate-build-version
remote:
remote: Verifying deploy...
remote:
remote: !       Push rejected to brahyt-dev-24.
remote:
To https://git.heroku.com/brahyt-dev-24.git
 ! [remote rejected] main -> main (pre-receive hook declined)
error: failed to push some refs to 'https://git.heroku.com/brahyt-dev-24.git'```