### PR TITLE
Remove duplicate URL from deprecation message and fix indentation

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -15,11 +15,11 @@ BUILDPACK_DIR="$(dirname $(dirname $0))"
 
 if ! command -v stunnel4 > /dev/null; then
 
-    echo "! This buildpack uses stunnel, which isn’t supported on heroku-24 and later." >&2
-    echo "! You don’t need this buildpack for Redis 6+. Remove it with the command:" >&2
-    echo "! $ heroku buildpacks:remove heroku/redis" >&2
-    echo "! To use Redis’ native TLS support, see:" >&2
-    echo "! https://devcenter.heroku.com/articles/heroku-redis#security-and-compliance" >&2
+    echo " !     This buildpack uses stunnel, which isn’t supported on heroku-24 and later." >&2
+    echo " !     You don’t need this buildpack for Redis 6+. Remove it with the command:" >&2
+    echo " !     $ heroku buildpacks:remove heroku/redis" >&2
+    echo " !     To use Redis’ native TLS support, see:" >&2
+    echo " !     https://devcenter.heroku.com/articles/heroku-redis#security-and-compliance" >&2
 
     exit 1
 fi

--- a/bin/compile
+++ b/bin/compile
@@ -18,7 +18,7 @@ if ! command -v stunnel4 > /dev/null; then
     echo "! This buildpack uses stunnel, which isn’t supported on heroku-24 and later." >&2
     echo "! You don’t need this buildpack for Redis 6+. Remove it with the command:" >&2
     echo "! $ heroku buildpacks:remove heroku/redis" >&2
-    echo "! To use Redis’ native TLS support, see https://devcenter.heroku.com/articles/heroku-redis#security-and-compliance:" >&2
+    echo "! To use Redis’ native TLS support, see:" >&2
     echo "! https://devcenter.heroku.com/articles/heroku-redis#security-and-compliance" >&2
 
     exit 1


### PR DESCRIPTION
Fixes the duplicate URL + long ling wrapping seen currently:

```
-----> Redis-stunnel app detected
! This buildpack uses stunnel, which isn’t supported on heroku-24 and later.
! You don’t need this buildpack for Redis 6+. Remove it with the command:
! $ heroku buildpacks:remove heroku/redis
! To use Redis’ native TLS support, see https://devcenter.heroku.com/articles/heroku-redis#security-and-compliance:
! https://devcenter.heroku.com/articles/heroku-redis#security-and-compliance
 !     Push rejected, failed to compile Redis-stunnel app.
```

GUS-W-15901890.