### PR TITLE
Update buildpack removal message

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -18,6 +18,9 @@ if ! command -v stunnel4 > /dev/null; then
     echo " !     This buildpack uses stunnel, which isn’t supported on heroku-24 and later." >&2
     echo " !     You don’t need this buildpack for Redis 6+. Remove it with the command:" >&2
     echo " !     $ heroku buildpacks:remove heroku/redis" >&2
+    echo " !" >&2
+    echo " !     Then remove any references to 'bin/start-stunnel' from your Procfile." >&2
+    echo " !" >&2
     echo " !     To use Redis’ native TLS support, see:" >&2
     echo " !     https://devcenter.heroku.com/articles/heroku-redis#security-and-compliance" >&2
 


### PR DESCRIPTION
This updates the buildpack removal error message shown on Heroku-24 to also remind users to remove the `bin/start-stunnel` from their `Procfile`.

This helps avoid users deploying only to then encounter an error on app boot:

```
/app/bin/start-stunnel: No such file or directory
```

As seen [here](https://salesforce-internal.slack.com/archives/C02Q86SF9UM/p1738892170827839?thread_ts=1738890582.758459&cid=C02Q86SF9UM).