### PR TITLE
maint: retire buildpack

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # Heroku buildpack: Redis Stunnel
 
+> [!CAUTION]
+> This buildpack has reached end-of-life, as [Heroku KVS](https://devcenter.heroku.com/articles/heroku-redis) only supports native TLS.
+>
+> We encourage customers to remove this buildpack using `heroku buildpacks:remove heroku/redis -a <app>`.
+
 This is a [Heroku buildpack](http://devcenter.heroku.com/articles/buildpacks) that
 allows an application to use an [stunnel](http://stunnel.org) to connect securely to
 Heroku Redis.  It is meant to be used in conjunction with other buildpacks.

--- a/bin/compile
+++ b/bin/compile
@@ -16,7 +16,7 @@ BUILDPACK_DIR="$(dirname $(dirname $0))"
 if ! command -v stunnel4 > /dev/null; then
 
     echo " !     This buildpack uses stunnel, which isn’t supported on heroku-24 and later." >&2
-    echo " !     You don’t need this buildpack for Redis 6+. Remove it with the command:" >&2
+    echo " !     You don’t need this buildpack for Heroku KVS 6+. Remove it with the command:" >&2
     echo " !     $ heroku buildpacks:remove heroku/redis" >&2
     echo " !" >&2
     echo " !     Then remove any references to 'bin/start-stunnel' from your Procfile." >&2
@@ -26,6 +26,15 @@ if ! command -v stunnel4 > /dev/null; then
 
     exit 1
 fi
+
+echo " !     This buildpack has reached end-of-life." >&2
+echo " !     You don’t need this buildpack for Heroku KVS 6+. Remove it with the command:" >&2
+echo " !     $ heroku buildpacks:remove heroku/redis" >&2
+echo " !" >&2
+echo " !     Then remove any references to 'bin/start-stunnel' from your Procfile." >&2
+echo " !" >&2
+echo " !     To use Redis’ native TLS support, see:" >&2
+echo " !     https://devcenter.heroku.com/articles/heroku-redis#security-and-compliance" >&2
 
 echo "-----> Moving the configuration generation script into app/bin"
 mkdir -p $BUILD_DIR/bin


### PR DESCRIPTION
This buildpack has now reached end-of-life, as [Heroku KVS](https://devcenter.heroku.com/articles/heroku-redis) now only supports versions that use [native TLS](https://valkey.io/topics/encryption/).

Ref: https://github.com/heroku/heroku-buildpack-redis/pull/49#issuecomment-2642831244